### PR TITLE
Adding gasLimit validation

### DIFF
--- a/src/test/jmeter/JSON-RPC.jmx
+++ b/src/test/jmeter/JSON-RPC.jmx
@@ -6938,7 +6938,7 @@
               <collectionProp name="Asserion.test_strings">
                 <stringProp name="-511124204">{&quot;jsonrpc&quot;:&quot;2.0&quot;,&quot;id&quot;:11,&quot;result&quot;:&quot;0x</stringProp>
                 <stringProp name="-1016682829">{&quot;jsonrpc&quot;:&quot;2.0&quot;,&quot;id&quot;:12,&quot;result&quot;:&quot;0x</stringProp>
-                <stringProp name="254578796">{&quot;jsonrpc&quot;:&quot;2.0&quot;,&quot;method&quot;:&quot;eth_subscription&quot;,&quot;params&quot;:{&quot;subscription&quot;:&quot;0x</stringProp>
+                <stringProp name="254578796">{&quot;jsonrpc&quot;:&quot;2.0&quot;,&quot;method&quot;:&quot;eth_subscription&quot;,&quot;params&quot;:{&quot;subscription&quot;:&quot;0x.+?&quot;,&quot;result&quot;:{&quot;difficulty&quot;:&quot;0x1&quot;,&quot;extraData&quot;:&quot;0x.+?&quot;,&quot;gasLimit&quot;:&quot;0x[^0][^0].+?&quot;</stringProp>
               </collectionProp>
               <stringProp name="Assertion.custom_message"></stringProp>
               <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>


### PR DESCRIPTION
### Description

This PR adds a validation for gasLimit value which is returned after to suscribe to the node.
This value should return without leading zeros.

The following regular expression was added to Response Assert in JMeter:

```
{"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0x.+?","result":{"difficulty":"0x1","extraData":"0x.+?","gasLimit":"0x[^0][^0].+?"
```

<img width="659" alt="Screen Shot 2021-08-16 at 10 05 30" src="https://user-images.githubusercontent.com/85762403/129588356-b1257350-22e8-4438-b471-0dbee9356332.png">

### Motivation and Context

Include the validation for CORE-540 which fix the reported issue.
