### PR TITLE
Adding websocket tests for non-numeric IDs

### DIFF
--- a/src/test/jmeter/JSON-RPC.jmx
+++ b/src/test/jmeter/JSON-RPC.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.1.1 r1855137">
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.4.1">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Test Plan" enabled="true">
       <stringProp name="TestPlan.comments"></stringProp>
@@ -109,6 +109,7 @@
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
         <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
       </ThreadGroup>
       <hashTree>
         <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="General Assertions" enabled="true">
@@ -3788,6 +3789,7 @@
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
         <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
       </ThreadGroup>
       <hashTree>
         <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="General Assertions" enabled="true">
@@ -3831,6 +3833,32 @@
           <stringProp name="connectTimeout">20000</stringProp>
           <boolProp name="binaryPayload">false</boolProp>
           <stringProp name="requestData">{&quot;jsonrpc&quot;:&quot;2.0&quot;,&quot;id&quot;:12,&quot;method&quot;:&quot;eth_subscribe&quot;, &quot;params&quot;:[&quot;logs&quot;,{}]}</stringProp>
+          <boolProp name="createNewConnection">false</boolProp>
+          <boolProp name="loadDataFromFile">false</boolProp>
+          <stringProp name="dataFile"></stringProp>
+        </eu.luminis.jmeter.wssampler.SingleWriteWebSocketSampler>
+        <hashTree/>
+        <eu.luminis.jmeter.wssampler.SingleWriteWebSocketSampler guiclass="eu.luminis.jmeter.wssampler.SingleWriteWebSocketSamplerGui" testclass="eu.luminis.jmeter.wssampler.SingleWriteWebSocketSampler" testname="eth_subscrine newHeads non_numeric id" enabled="true">
+          <boolProp name="TLS">false</boolProp>
+          <stringProp name="server"></stringProp>
+          <stringProp name="port">80</stringProp>
+          <stringProp name="path"></stringProp>
+          <stringProp name="connectTimeout">20000</stringProp>
+          <boolProp name="binaryPayload">false</boolProp>
+          <stringProp name="requestData">{&quot;jsonrpc&quot;:&quot;2.0&quot;,&quot;id&quot;:&quot;449b48ac-86ce-4901-ba1f-220f3b290338&quot;,&quot;method&quot;:&quot;eth_subscribe&quot;, &quot;params&quot;:[&quot;newHeads&quot;,{}]}</stringProp>
+          <boolProp name="createNewConnection">false</boolProp>
+          <boolProp name="loadDataFromFile">false</boolProp>
+          <stringProp name="dataFile"></stringProp>
+        </eu.luminis.jmeter.wssampler.SingleWriteWebSocketSampler>
+        <hashTree/>
+        <eu.luminis.jmeter.wssampler.SingleWriteWebSocketSampler guiclass="eu.luminis.jmeter.wssampler.SingleWriteWebSocketSamplerGui" testclass="eu.luminis.jmeter.wssampler.SingleWriteWebSocketSampler" testname="eth_subscribe logs non_numeric id" enabled="true">
+          <boolProp name="TLS">false</boolProp>
+          <stringProp name="server"></stringProp>
+          <stringProp name="port">80</stringProp>
+          <stringProp name="path"></stringProp>
+          <stringProp name="connectTimeout">20000</stringProp>
+          <boolProp name="binaryPayload">false</boolProp>
+          <stringProp name="requestData">{&quot;jsonrpc&quot;:&quot;2.0&quot;,&quot;id&quot;:&quot;449b48ac-86ce-4901-ba1f-220f3b290338&quot;,&quot;method&quot;:&quot;eth_subscribe&quot;, &quot;params&quot;:[&quot;logs&quot;,{}]}</stringProp>
           <boolProp name="createNewConnection">false</boolProp>
           <boolProp name="loadDataFromFile">false</boolProp>
           <stringProp name="dataFile"></stringProp>
@@ -6919,7 +6947,7 @@
         </hashTree>
         <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
           <boolProp name="LoopController.continue_forever">true</boolProp>
-          <stringProp name="LoopController.loops">3</stringProp>
+          <stringProp name="LoopController.loops">5</stringProp>
         </LoopController>
         <hashTree>
           <eu.luminis.jmeter.wssampler.SingleReadWebSocketSampler guiclass="eu.luminis.jmeter.wssampler.SingleReadWebSocketSamplerGui" testclass="eu.luminis.jmeter.wssampler.SingleReadWebSocketSampler" testname="WebSocket Single Read Sampler" enabled="true">
@@ -6932,13 +6960,15 @@
             <boolProp name="createNewConnection">false</boolProp>
             <stringProp name="readTimeout">6000</stringProp>
             <boolProp name="optional">false</boolProp>
+            <stringProp name="dataType">Text</stringProp>
           </eu.luminis.jmeter.wssampler.SingleReadWebSocketSampler>
           <hashTree>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
               <collectionProp name="Asserion.test_strings">
                 <stringProp name="-511124204">{&quot;jsonrpc&quot;:&quot;2.0&quot;,&quot;id&quot;:11,&quot;result&quot;:&quot;0x</stringProp>
                 <stringProp name="-1016682829">{&quot;jsonrpc&quot;:&quot;2.0&quot;,&quot;id&quot;:12,&quot;result&quot;:&quot;0x</stringProp>
-                <stringProp name="254578796">{&quot;jsonrpc&quot;:&quot;2.0&quot;,&quot;method&quot;:&quot;eth_subscription&quot;,&quot;params&quot;:{&quot;subscription&quot;:&quot;0x.+?&quot;,&quot;result&quot;:{&quot;difficulty&quot;:&quot;0x1&quot;,&quot;extraData&quot;:&quot;0x.+?&quot;,&quot;gasLimit&quot;:&quot;0x[^0][^0].+?&quot;</stringProp>
+                <stringProp name="-958694103">{&quot;jsonrpc&quot;:&quot;2.0&quot;,&quot;id&quot;:&quot;449b48ac-86ce-4901-ba1f-220f3b290338&quot;,&quot;result&quot;:&quot;0x</stringProp>
+                <stringProp name="-36311230">{&quot;jsonrpc&quot;:&quot;2.0&quot;,&quot;method&quot;:&quot;eth_subscription&quot;,&quot;params&quot;:{&quot;subscription&quot;:&quot;0x.+?&quot;,&quot;result&quot;:{&quot;difficulty&quot;:&quot;0x1&quot;,&quot;extraData&quot;:&quot;0x.+?&quot;,&quot;gasLimit&quot;:&quot;0x[^0][^0].+?&quot;</stringProp>
               </collectionProp>
               <stringProp name="Assertion.custom_message"></stringProp>
               <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -6960,6 +6990,7 @@
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
         <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
       </ThreadGroup>
       <hashTree>
         <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="eth_getBlockByNumber (Not failing but required to reuse Hash)" enabled="true">
@@ -7627,6 +7658,7 @@
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
         <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
       </ThreadGroup>
       <hashTree>
         <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="shh_addToGroup" enabled="true">
@@ -8250,6 +8282,7 @@
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
         <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
       </ThreadGroup>
       <hashTree>
         <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="eth_getBlockByNumber pending true" enabled="true">


### PR DESCRIPTION
### Description

Adding two new websocket requests for method `eth_subscrine` which now supports non-numeric IDs:

**newHeads**
```
{"jsonrpc":"2.0","id":"449b48ac-86ce-4901-ba1f-220f3b290338","method":"eth_subscribe", "params":["newHeads",{}]}
```

**logs**
```
{"jsonrpc":"2.0","id":"449b48ac-86ce-4901-ba1f-220f3b290338","method":"eth_subscribe", "params":["logs",{}]}
```

### Evidence

Tested in master:

https://app.circleci.com/pipelines/github/rsksmart/json-rpc-jmeter/774/workflows/20870507-7d06-49a2-81de-23f17afdc539/jobs/961